### PR TITLE
Fix audio processor cleanup

### DIFF
--- a/content.js
+++ b/content.js
@@ -154,6 +154,8 @@ async function processAudioStream(stream) {
         `], { type: 'application/javascript' })));
 
         const workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
+        // Expose the node globally so it can be disconnected later
+        audioProcessor = workletNode;
         
         workletNode.port.onmessage = async (event) => {
             if (!isCapturing) return;
@@ -213,7 +215,13 @@ async function stopAudioCapture() {
     isCapturing = false;
 
     if (audioProcessor) {
-        audioProcessor.disconnect();
+        try {
+            audioProcessor.port.onmessage = null;
+            audioProcessor.disconnect();
+            console.log("Audio processor disconnected.");
+        } catch (e) {
+            console.error("Error disconnecting audio processor:", e);
+        }
         audioProcessor = null;
     }
     


### PR DESCRIPTION
## Summary
- expose created `AudioWorkletNode` via the `audioProcessor` global
- ensure audio processor disconnects safely during capture stop

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6845562153d8832a82259ecbf1f1360a